### PR TITLE
feat: introduce structured EricError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "anyhow",
  "eric-bindings",
  "roxmltree",
+ "thiserror",
 ]
 
 [[package]]
@@ -209,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -287,13 +288,33 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ repository = "https://github.com/quambene/eric-rs"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
+thiserror = "2.0.18"

--- a/eric-sdk/Cargo.toml
+++ b/eric-sdk/Cargo.toml
@@ -30,6 +30,7 @@ docs-rs = ["eric-bindings/docs-rs"]
 [dependencies]
 eric-bindings = { version = "0.5.0", path = "../eric-bindings" }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 roxmltree = "0.20.0"

--- a/eric-sdk/src/eric.rs
+++ b/eric-sdk/src/eric.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{CertificateConfig, PrintConfig},
+    error::EricError,
     error_code::ErrorCode,
     response::{EricResponse, ResponseBuffer},
     utils::ToCString,
@@ -63,7 +64,7 @@ impl Eric {
         taxonomy_type: &str,
         taxonomy_version: &str,
         pdf_path: Option<&str>,
-    ) -> Result<EricResponse, anyhow::Error> {
+    ) -> Result<EricResponse, EricError> {
         let processing_flag: ProcessingFlag;
         let type_version = format!("{}_{}", taxonomy_type, taxonomy_version);
         let print_config = if let Some(pdf_path) = pdf_path {
@@ -88,7 +89,7 @@ impl Eric {
         taxonomy_type: &str,
         taxonomy_version: &str,
         pdf_path: Option<&str>,
-    ) -> Result<EricResponse, anyhow::Error> {
+    ) -> Result<EricResponse, EricError> {
         let certificate_path = env::var("CERTIFICATE_PATH")
             .context("Missing environment variable 'CERTIFICATE_PATH'")?;
         let certificate_password = env::var("CERTIFICATE_PASSWORD")
@@ -153,7 +154,7 @@ impl Eric {
         print_config: Option<PrintConfig>,
         certificate_config: Option<CertificateConfig>,
         transfer_code: Option<u32>,
-    ) -> Result<EricResponse, anyhow::Error> {
+    ) -> Result<EricResponse, EricError> {
         println!("Processing xml file");
 
         match processing_flag {
@@ -178,7 +179,7 @@ impl Eric {
         match &print_config {
             Some(print_config) => println!(
                 "Printing confirmation to file '{}'",
-                print_config.pdf_path.to_str()?
+                print_config.pdf_path.to_str().context("failed to convert path to string")?
             ),
             None => (),
         }
@@ -227,12 +228,12 @@ impl Eric {
                 EricHoleFehlerText(error_code, response_buffer.as_ptr());
             }
             let error_text = response_buffer.read()?;
-            return Err(anyhow!(
-                "processing failed with error code {}: {}\nServer response: {}",
-                error_code,
-                error_text,
-                server_response
-            ));
+            return Err(EricError::ApiError {
+                code: error_code,
+                message: error_text.to_string(),
+                validation_response: validation_response.to_string(),
+                server_response: server_response.to_string(),
+            });
         }
 
         let response = EricResponse::new(

--- a/eric-sdk/src/error.rs
+++ b/eric-sdk/src/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EricError {
+    #[error("API Error (code={code}): {message}, validation={validation_response}, server={server_response}")]
+    ApiError {
+        code: i32,
+        message: String,
+        validation_response: String,
+        server_response: String,
+    },
+    /// Unstructured catch all for internal errors
+    #[error("Internal error: {0}")]
+    Internal(#[from] anyhow::Error),
+}

--- a/eric-sdk/src/lib.rs
+++ b/eric-sdk/src/lib.rs
@@ -1,11 +1,13 @@
 mod certificate;
 mod config;
 mod eric;
+mod error;
 mod error_code;
 mod response;
 mod utils;
 
 pub use eric::Eric;
+pub use error::EricError;
 pub use error_code::ErrorCode;
 pub use response::EricResponse;
 


### PR DESCRIPTION
Introduces a structured EricError type to replace opaque error strings. The SDK now preserves the validation_response and server_response buffers when an ERiC error occurs, allowing downstream services to report specific validation failures.