### PR TITLE
chore(eric-bindings): make bindgen comments opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,14 @@ jobs:
         run: cargo package -p eric-bindings --features docs-rs
       # - name: cargo package -p eric-sdk
       #   run: cargo package -p eric-sdk --features docs-rs
+  bindings-no-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert no `#[doc = ...]` in committed bindings
+        run: |
+          if grep -RnE '^\s*#\[doc = ' eric-bindings/bindings/; then
+            echo "::error::Committed bindings include #[doc = ...] attributes."
+            echo "Regenerate with --features generate-bindings (without bindgen-comments)."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ cargo build -p eric-bindings --features generate-bindings
 The bindings are generated in
 `target/debug/build/eric-bindings-<random-id>/out/bindings.rs`.
 
+By default the generated output matches the comment-free shape of the
+bundled binding files. Add the `bindgen-comments` feature to include the
+documentation from the C header:
+
+``` bash
+cargo build -p eric-bindings --features "generate-bindings bindgen-comments"
+```
+
 To generate the bindings on your platform and architecture, you need `libclang` as well. For example, on Debian/Ubuntu install:
 
 ``` bash

--- a/eric-bindings/Cargo.toml
+++ b/eric-bindings/Cargo.toml
@@ -30,6 +30,9 @@ features = ["docs-rs"]
 [features]
 default = []
 generate-bindings = ["dep:bindgen"]
+# Opt-in: include comments from the C header in generated bindings.
+# Default off so generated output matches the committed bundled shape.
+bindgen-comments = []
 # This feature is used in CI pipeline for unit tests.
 no-linking = []
 # This feature is used to publish the documentation for `eric-bindings`.

--- a/eric-bindings/build.rs
+++ b/eric-bindings/build.rs
@@ -122,11 +122,16 @@ fn generate_bindings() -> io::Result<()> {
 
     let header = header_file.to_str().expect("Can't convert path to string");
 
+    let include_comments = env::var("CARGO_FEATURE_BINDGEN_COMMENTS").is_ok();
+
     let bindings = bindgen::Builder::default()
         .header(header)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate_comments(include_comments)
         .generate()
         .expect("Can't generate bindings");
+
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_BINDGEN_COMMENTS");
 
     let out_dir = env::var("OUT_DIR").expect("environment variable `OUT_DIR` not set");
     let output_path = PathBuf::from(out_dir);


### PR DESCRIPTION
Two-commit prequel aligning the `generate-bindings` output with the
comment-free shape that ships in `sdk-0.6.0`.

- `chore(eric-bindings): make bindgen comments opt-in` — adds a
  `bindgen-comments` Cargo feature; `build.rs` passes it through to
  `bindgen::Builder::generate_comments(...)`. Default is off, matching
  the committed bundled shape. README notes the opt-in.
- `ci: assert no doc attributes in committed bindings` — new
  `bindings-no-docs` job greps `eric-bindings/bindings/` for
  `#[doc = ...]` attributes and fails if any are found. Baseline on
  `main` passes the grep.